### PR TITLE
Moved TtyCheck out of default package

### DIFF
--- a/src/main/java/org/rnorth/TtyCheck.java
+++ b/src/main/java/org/rnorth/TtyCheck.java
@@ -1,3 +1,5 @@
+package org.rnorth;
+
 import org.rnorth.ansi.CapabilityDetection;
 
 import static org.rnorth.ansi.AnsiLite.green;


### PR DESCRIPTION
The presence of the TtyCheck in the default package space causes problems when using this library from OSGI